### PR TITLE
Broken `GETTING_STARTED.md` Link

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -2,7 +2,7 @@
 ## Detectron2 Demo
 
 We provide a command line tool to run a simple demo of builtin configs.
-The usage is explained in [GETTING_STARTED.md](../GETTING_STARTED.md).
+The usage is explained in [GETTING_STARTED.md](https://github.com/facebookresearch/detectron2/blob/main/GETTING_STARTED.md).
 
 See our [blog post](https://ai.facebook.com/blog/-detectron2-a-pytorch-based-modular-object-detection-library-)
 for a high-quality demo generated with this tool.


### PR DESCRIPTION
`GETTING_STARTED.md` is currently unavailable. I suggest that the link points to `detectron2/GETTING_STARTED.md` or we upload a copy of `GETTING_STARTED.md` and have the link point to that copy.